### PR TITLE
Fix The issue when user exits it only shows cancelled by user Process exited

### DIFF
--- a/go_cli.py
+++ b/go_cli.py
@@ -156,10 +156,10 @@ def main():
         selected_command = go_questionary.select(
             "", choices=commands, instruction=""
         ).ask()
-        exit_condition = execute_command(selected_command)
         if selected_command==None:
             print('Process Exited')
             exit();
+        exit_condition = execute_command(selected_command)
         # Commands failed / succeeded?
         try:
             response = requests.post(

--- a/go_cli.py
+++ b/go_cli.py
@@ -157,7 +157,9 @@ def main():
             "", choices=commands, instruction=""
         ).ask()
         exit_condition = execute_command(selected_command)
-
+        if selected_command==None:
+            print('Process Exited')
+            exit();
         # Commands failed / succeeded?
         try:
             response = requests.post(


### PR DESCRIPTION
# When User exits via keyboard Interupt
Whenever user exits the process via keyboard interupt like CTRL+C (NoneType is passed which) it shows error in terminal as Follow 
## Before
![image](https://github.com/gorilla-llm/gorilla-cli/assets/48846069/c4fac30c-0d32-4a92-b4d8-3b08d60b6b4b)

## After Fix 
![image](https://github.com/gorilla-llm/gorilla-cli/assets/48846069/08af5ba0-cc5c-441f-93d7-65007cd32616)


  