### PR TITLE
fix: utf-8 decoding error

### DIFF
--- a/go_cli.py
+++ b/go_cli.py
@@ -121,7 +121,7 @@ def get_user_id():
 def main():
     def execute_command(cmd):
         process = subprocess.run(cmd, shell=True, stderr=subprocess.PIPE)
-        error_msg = process.stderr.decode("utf-8")
+        error_msg = process.stderr.decode("utf-8", "ignore")
         if error_msg:
             print(f"{error_msg}")
             return error_msg


### PR DESCRIPTION
Reference Issue: https://github.com/ShishirPatil/gorilla/issues/88

Sometimes decoding the sub-process error message seems to throw unrezognized characters especially on windows PC. This should fix that - we will ignore those characters that cannot be decoded. 