### PR TITLE
Transition to HTTPS from HTTP in version 0.0.10

### DIFF
--- a/go_cli.py
+++ b/go_cli.py
@@ -24,7 +24,7 @@ from halo import Halo
 import go_questionary
 
 __version__ = "0.0.9"  # current version
-SERVER_URL = "http://34.135.112.197:8000"
+SERVER_URL = "https://cli.gorilla-llm.com"
 UPDATE_CHECK_FILE = os.path.expanduser("~/.gorilla-cli-last-update-check")
 USERID_FILE = os.path.expanduser("~/.gorilla-cli-userid")
 ISSUE_URL = f"https://github.com/gorilla-llm/gorilla-cli/issues/new"

--- a/go_cli.py
+++ b/go_cli.py
@@ -23,7 +23,7 @@ import sys
 from halo import Halo
 import go_questionary
 
-__version__ = "0.0.9"  # current version
+__version__ = "0.0.10"  # current version
 SERVER_URL = "https://cli.gorilla-llm.com"
 UPDATE_CHECK_FILE = os.path.expanduser("~/.gorilla-cli-last-update-check")
 USERID_FILE = os.path.expanduser("~/.gorilla-cli-userid")

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="gorilla-cli",
-    version="0.0.9",
+    version="0.0.10",
     url="https://github.com/gorilla-llm/gorilla-cli",
     author="Shishir Patil, Tianjun Zhang",
     author_email="sgp@berkeley.edu, tianjunz@berkeley.edu",


### PR DESCRIPTION
Transitioning from HTTP to HTTPS with Version 0.0.10. Kudos to @jclyons52, @samstride, and @ricklamers for flagging this concern in Issue #7.

To ensure a smooth user experience, we will maintain support for the existing HTTP protocol used in releases up to v0.0.9. The merge is expected to be seamless.