### PR TITLE
Get OS and prefill shell with user commands

### DIFF
--- a/go_cli.py
+++ b/go_cli.py
@@ -178,9 +178,10 @@ def main():
                 "user_id": user_id,
                 "user_input": user_input,
                 "interaction_id": interaction_id,
+                "system_info": system_info,
             }
             response = requests.post(
-                f"{SERVER_URL}/commands", json=data_json, timeout=30
+                f"{SERVER_URL}/commands_v2", json=data_json, timeout=30
             )
             commands = response.json()
         except requests.exceptions.RequestException as e:

--- a/go_cli.py
+++ b/go_cli.py
@@ -26,7 +26,7 @@ import sys
 from halo import Halo
 import go_questionary
 
-__version__ = "0.0.10"  # current version
+__version__ = "0.0.11"  # current version
 SERVER_URL = "https://cli.gorilla-llm.com"
 UPDATE_CHECK_FILE = os.path.expanduser("~/.gorilla-cli-last-update-check")
 USERID_FILE = os.path.expanduser("~/.gorilla-cli-userid")

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="gorilla-cli",
-    version="0.0.10",
+    version="0.0.11",
     url="https://github.com/gorilla-llm/gorilla-cli",
     author="Shishir Patil, Tianjun Zhang",
     author_email="sgp@berkeley.edu, tianjunz@berkeley.edu",


### PR DESCRIPTION
- [X] Append command to user bash history and prefill shell. Even though we can append command to bash history, it does not show up in the reverse-i-search without sourcing the shell. This is because the child process cannot modify the environment of the parent caller process [stack-overflow reference](https://stackoverflow.com/questions/3661566/python-source-home-bashrc-with-os-system). So, instead will will pre-fill the shell command with the selected command. 
- [X] Get OS environment
- [X] Refactor unique ID generation - mostly cosmetic 
- [x] Update server to route LLM based on os environment
- [x] Test on Ubuntu Linux
- [x] Test on Darwin (Mac OS)
- [ ] Test on WSL
- [ ] Test on Windows Powershell

Thoughts, suggestions, and reviews welcome!

Relevant to #39 and #12 


