### PR TITLE
Exits silently on Ctrl-C

### DIFF
--- a/go_cli.py
+++ b/go_cli.py
@@ -167,6 +167,10 @@ def main():
         selected_command = go_questionary.select(
             "", choices=commands, instruction=""
         ).ask()
+
+        if not selected_command:
+            # happens when Ctrl-C is pressed
+            return
         exit_condition = execute_command(selected_command)
 
         # Commands failed / succeeded?


### PR DESCRIPTION
Fix for https://github.com/gorilla-llm/gorilla-cli/issues/44

Avoids displaying a stack trace when `selected_command` is `None` because the user didn't select any of the entries