### PR TITLE
Windows installer for CLI

### DIFF
--- a/setup_executable.py
+++ b/setup_executable.py
@@ -1,0 +1,8 @@
+# script packaged into a single setup.exe file
+import os
+
+def install(package):
+	os.system(f"python -m pip install {package}")
+
+if __name__ == "__main__":
+	install("gorilla-cli")


### PR DESCRIPTION
Adds a windows installer to automate pip install for gorilla-cli, addressing Ideas discussion [#103](https://github.com/ShishirPatil/gorilla/discussions/103) and QnA discussion #40. Requires Python and pip to be installed on the user's machine, but completely automates installation process of gorilla-cli.