### PR TITLE
Added history feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,24 @@ $ gorilla get the image ids of all pods running in all namespaces in kubernetes
 
 Gorilla-CLI fuses the capabilities of various Language Learning Models (LLMs) like [Gorilla LLM](https://github.com/ShishirPatil/gorilla/), OpenAI's GPT-4, Claude v1, and others to present a user-friendly command-line interface. For each user query, we gather responses from all contributing LLMs, filter, sort, and present you with the most relevant options. 
 
+### Arguments
+
+```
+usage: go_cli.py [-h] [-p] [command_args ...]
+
+Gorilla CLI Help Doc
+
+positional arguments:
+  command_args   Prompt to be inputted to Gorilla
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -p, --history  Display command history
+```
+
+The history feature lets the user go back to previous commands they've executed to re-execute in a similar fashion to terminal history.
+
+
 ## Contributions
 
 We welcome your enhancements to Gorilla CLI! If you have improvements, feel free to submit a pull request on our GitHub page. 

--- a/go_cli.py
+++ b/go_cli.py
@@ -31,6 +31,7 @@ USERID_FILE = os.path.expanduser("~/.gorilla-cli-userid")
 HISTORY_FILE = os.path.expanduser("~/.gorilla_cli_history")
 ISSUE_URL = f"https://github.com/gorilla-llm/gorilla-cli/issues/new"
 GORILLA_EMOJI = "🦍 " if go_questionary.try_encode_gorilla() else ""
+HISTORY_LENGTH = 5
 WELCOME_TEXT = f"""===***===
 {GORILLA_EMOJI}Welcome to Gorilla-CLI! Enhance your Command Line with the power of LLMs! 
 
@@ -148,7 +149,7 @@ def append_string_to_file_if_missing(file_path, target_string):
             lines = file.readlines()
 
         # Check if the target string is already in the file
-        if target_string not in lines:
+        if target_string not in lines[-HISTORY_LENGTH:]:
             with open(file_path, 'a') as file:
                 file.write(target_string)
     except FileNotFoundError:
@@ -162,7 +163,7 @@ def main():
         cmd = format_command(cmd)
         process = subprocess.run(cmd, shell=True, stderr=subprocess.PIPE)
 
-        save = cmd.startswith(':')
+        save = not cmd.startswith(':')
         if save:
             append_string_to_file_if_missing(HISTORY_FILE, cmd)
 
@@ -183,7 +184,7 @@ def main():
                 lines = history.readlines()
                 if not lines:
                     print("No command history.")
-                return lines[-10:]
+                return lines[-HISTORY_LENGTH:]
         else:
             print("No command history.")
             return
@@ -226,7 +227,7 @@ def main():
 
     if commands:
         selected_command = go_questionary.select(
-            "", choices=commands, instruction=""
+            "", choices=commands, instruction="Welcome to Gorilla. Use arrow keys to select. Ctrl-C to Exit"
         ).ask()
 
         if not selected_command:

--- a/go_cli.py
+++ b/go_cli.py
@@ -31,7 +31,7 @@ USERID_FILE = os.path.expanduser("~/.gorilla-cli-userid")
 HISTORY_FILE = os.path.expanduser("~/.gorilla_cli_history")
 ISSUE_URL = f"https://github.com/gorilla-llm/gorilla-cli/issues/new"
 GORILLA_EMOJI = "🦍 " if go_questionary.try_encode_gorilla() else ""
-HISTORY_LENGTH = 5
+HISTORY_LENGTH = 10
 WELCOME_TEXT = f"""===***===
 {GORILLA_EMOJI}Welcome to Gorilla-CLI! Enhance your Command Line with the power of LLMs! 
 
@@ -107,8 +107,9 @@ def get_user_id():
             )
             issue_body = urllib.parse.quote(f"Unable to generate userid: {str(e)}")
             print(
-                f"Git not installed, so cannot import userid from Git. \n Please run 'gorilla <command>' again after initializing git. \n Will use a random user-id. If the problem persists, please raise an issue: \
-                  {ISSUE_URL}?title={issue_title}&body={issue_body}"
+                f"Git not installed or not configured, so cannot import userid from Git.\nTry running \
+                  \n\ngit config --global user.email <your_email>\n\nPlease run 'gorilla <command>' again after initializing git. \n Will use a random user-id. If the problem persists, please raise an issue: \
+                  \n{ISSUE_URL}?title={issue_title}&body={issue_body}"
             )
             user_id = str(uuid.uuid4())
             print(WELCOME_TEXT)

--- a/go_cli.py
+++ b/go_cli.py
@@ -18,6 +18,7 @@ import sys
 import uuid
 import requests
 import subprocess
+import argparse
 import urllib.parse
 import sys
 from halo import Halo
@@ -27,6 +28,7 @@ __version__ = "0.0.10"  # current version
 SERVER_URL = "https://cli.gorilla-llm.com"
 UPDATE_CHECK_FILE = os.path.expanduser("~/.gorilla-cli-last-update-check")
 USERID_FILE = os.path.expanduser("~/.gorilla-cli-userid")
+HISTORY_FILE = os.path.expanduser("~/.gorilla_cli_history")
 ISSUE_URL = f"https://github.com/gorilla-llm/gorilla-cli/issues/new"
 GORILLA_EMOJI = "🦍 " if go_questionary.try_encode_gorilla() else ""
 WELCOME_TEXT = f"""===***===
@@ -128,38 +130,97 @@ def get_user_id():
             )
             return user_id
 
+def format_command(input_str):
+    """
+    Standardize commands to be stored with a newline
+    character in the history
+    """
+    if not input_str.endswith('\n'):
+        input_str += '\n'
+    return input_str
+
+def append_string_to_file_if_missing(file_path, target_string):
+    """
+    Don't append command to history file if it already exists.
+    """
+    try:
+        with open(file_path, 'r') as file:
+            lines = file.readlines()
+
+        # Check if the target string is already in the file
+        if target_string not in lines:
+            with open(file_path, 'a') as file:
+                file.write(target_string)
+    except FileNotFoundError:
+        # If the file doesn't exist, create it and append the string
+        with open(file_path, 'w') as file:
+            file.write(target_string)
+
 
 def main():
     def execute_command(cmd):
+        cmd = format_command(cmd)
         process = subprocess.run(cmd, shell=True, stderr=subprocess.PIPE)
+
+        save = cmd.startswith(':')
+        if save:
+            append_string_to_file_if_missing(HISTORY_FILE, cmd)
+
         error_msg = process.stderr.decode("utf-8", "ignore")
         if error_msg:
             print(f"{error_msg}")
             return error_msg
         return str(process.returncode)
 
+    def get_history_commands(history_file):
+        """
+        Takes in history file
+        Returns None if file doesn't exist or empty
+        Returns list of last 10 history commands in the file if it exists
+        """
+        if os.path.isfile(history_file):
+            with open(history_file, 'r') as history:
+                lines = history.readlines()
+                if not lines:
+                    print("No command history.")
+                return lines[-10:]
+        else:
+            print("No command history.")
+            return
+
     args = sys.argv[1:]
     user_input = " ".join(args)
     user_id = get_user_id()
 
+
+    # Parse command-line arguments
+    parser = argparse.ArgumentParser(description="Gorilla CLI Help Doc")
+    parser.add_argument("-p", "--history", action="store_true", help="Display command history")
+    parser.add_argument("command_args", nargs='*', help="Prompt to be inputted to Gorilla")
+
+    args = parser.parse_args()
+
     # Generate a unique interaction ID
     interaction_id = str(uuid.uuid4())
 
-    with Halo(text=f"{GORILLA_EMOJI}Loading", spinner="dots"):
-        try:
-            data_json = {
-                "user_id": user_id,
-                "user_input": user_input,
-                "interaction_id": interaction_id,
-            }
-            response = requests.post(
-                f"{SERVER_URL}/commands", json=data_json, timeout=30
-            )
-            commands = response.json()
-        except requests.exceptions.RequestException as e:
-            print("Server is unreachable.")
-            print("Try updating Gorilla-CLI with 'pip install --upgrade gorilla-cli'")
-            return
+    if args.history:
+        commands = get_history_commands(HISTORY_FILE)
+    else:
+        with Halo(text=f"{GORILLA_EMOJI}Loading", spinner="dots"):
+            try:
+                data_json = {
+                    "user_id": user_id,
+                    "user_input": user_input,
+                    "interaction_id": interaction_id,
+                }
+                response = requests.post(
+                    f"{SERVER_URL}/commands", json=data_json, timeout=30
+                )
+                commands = response.json()
+            except requests.exceptions.RequestException as e:
+                print("Server is unreachable.")
+                print("Try updating Gorilla-CLI with 'pip install --upgrade gorilla-cli'")
+                return
 
     check_for_updates()
 


### PR DESCRIPTION
The history feature (`-p` or `--history`) will allow users to find their past commands executed and execute them using the questionary selection feature.

The history will be stored in `~/.gorilla_cli_history` and currently, it is set so that the newest 5 commands in the history will be displayable (there is an adjustable constant for `HISTORY_LENGTH`). 

Repeated executions of the same command within the most recent 5 commands will not be appended to the history, but as long as that command is out of the recent window, it is again able to be added to the history list. This is to prevent cluttering of the history by repeated executions of the same command consecutively.

This address the issue #39 for bash history appending for executed commands. Since the CLI, using python, runs on a separate subprocess than the current user's shell, it is against best security practices to violate this subprocess distinction and force write to a global history. As well, since different shells work differently when tracking history (zsh, bash, cmd.exe), it is also a very big hassle to introduce cross-platform support. This is why I opted for this in-house history solution.

<img width="692" alt="image" src="https://github.com/gorilla-llm/gorilla-cli/assets/65890703/a1edd64f-a0da-4df6-a9c1-0b177bb4d0bb">
